### PR TITLE
핵심 원리 3 객체 지향 원리 적용

### DIFF
--- a/src/main/java/hello/core/AppConfig.java
+++ b/src/main/java/hello/core/AppConfig.java
@@ -1,0 +1,17 @@
+package hello.core;
+
+import hello.core.discount.FixDiscountPolicy;
+import hello.core.member.MemberService;
+import hello.core.member.MemberServiceImpl;
+import hello.core.member.MemoryMemberRepository;
+import hello.core.order.OrderService;
+import hello.core.order.OrderServiceImpl;
+
+public class AppConfig {
+    public MemberService memberService(){
+        return new MemberServiceImpl(new MemoryMemberRepository());
+    }
+    public OrderService orderService(){
+        return new OrderServiceImpl(new MemoryMemberRepository(), new FixDiscountPolicy());
+    }
+}

--- a/src/main/java/hello/core/MemberApp.java
+++ b/src/main/java/hello/core/MemberApp.java
@@ -9,7 +9,11 @@ import java.util.Arrays;
 
 public class MemberApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
+//        MemberService memberService = new MemberServiceImpl();
+
+        AppConfig appConfig = new AppConfig();
+        MemberService memberService = appConfig.memberService();
+
         Member member1 = new Member(1L, "member1", Grade.VIP);
         memberService.join(member1);
 

--- a/src/main/java/hello/core/OrderApp.java
+++ b/src/main/java/hello/core/OrderApp.java
@@ -5,8 +5,12 @@ import hello.core.order.*;
 
 public class OrderApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
-        OrderService orderService = new OrderServiceImpl();
+//      MemberService memberService = new MemberServiceImpl();
+//      OrderService orderService = new OrderServiceImpl();
+
+        AppConfig appConfig = new AppConfig();
+        MemberService memberService = appConfig.memberService();
+        OrderService orderService = appConfig.orderService();
 
         long memberId = 1L;
         Member member = new Member(memberId, "MemberA", Grade.VIP);

--- a/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -1,0 +1,15 @@
+package hello.core.discount;
+
+import hello.core.member.Grade;
+import hello.core.member.Member;
+
+public class RateDiscountPolicy implements DiscountPolicy{
+    private int discountPercent = 10; // 정율 할인 퍼센트
+    @Override
+    public int discount(Member member, int price) {
+        if(member.getGrade() == Grade.VIP)
+            return price * discountPercent / 100;
+        else
+            return 0;
+    }
+}

--- a/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -2,7 +2,12 @@ package hello.core.member;
 
 public class MemberServiceImpl implements MemberService{
 
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
+//  private final MemberRepository memberRepository = new MemoryMemberRepository();
+    private final MemberRepository memberRepository;
+
+    public MemberServiceImpl(MemberRepository memberRepository){
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public void join(Member member) {

--- a/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -8,8 +8,14 @@ import hello.core.member.MemoryMemberRepository;
 
 public class OrderServiceImpl implements OrderService{
 
-    private final MemberRepository memberRepository = new MemoryMemberRepository();
-    private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
+//    private final MemberRepository memberRepository = new MemoryMemberRepository();
+//    private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
+    private final MemberRepository memberRepository;
+    private final DiscountPolicy discountPolicy;
+    public OrderServiceImpl(MemberRepository memberRepository,DiscountPolicy discountPolicy){
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {

--- a/src/test/java/hello/core/discount/RateDiscountPolicyTest.java
+++ b/src/test/java/hello/core/discount/RateDiscountPolicyTest.java
@@ -1,0 +1,25 @@
+package hello.core.discount;
+
+import hello.core.member.Grade;
+import hello.core.member.Member;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class RateDiscountPolicyTest {
+    DiscountPolicy discountPolicy = new RateDiscountPolicy();
+    @Test
+    @DisplayName("VIP 10% 할인")
+    void vip_o(){
+        Member member = new Member(1L,"memberVIP", Grade.VIP);
+        int discount = discountPolicy.discount(member,10000);
+        Assertions.assertThat(discount).isEqualTo(1000);
+    }
+    @Test
+    @DisplayName("BASIC 할인 없음")
+    void vip_x(){
+        Member member = new Member(1L,"memberBASIC", Grade.BASIC);
+        int discount = discountPolicy.discount(member,10000);
+        Assertions.assertThat(discount).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
할인정책 추가와 OCP, DIP 위반, 구현체 의존으로 가지는 문제를 해결하기위해서

구현체에 의존하던 부분은 구현체가 아닌 인터페이스 변수만을 두고,

생성자를 호출을 통해 주입되도록 만듬.

AppConfig를 생성하여 해당 부분에서 구현체 인스턴스 생성 및 주입

AppConfig는 Main에서만 사용됨